### PR TITLE
[Issue #198] Replaced encode_filename with encodeURIComponent for imp…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
+java-backend/.vscode/launch.json
+java-backend/.vscode/launch.test.json

--- a/java-backend/src/test/java/org/comixed/web/controllers/FileControllerTest.java
+++ b/java-backend/src/test/java/org/comixed/web/controllers/FileControllerTest.java
@@ -66,7 +66,7 @@ public class FileControllerTest
     {"First.cbz",
      "Second.cbz",
      "Third.cbr",
-     "Fourth.cb7"};;
+     "Fourth.cb7"};
 
     @InjectMocks
     private FileController controller;
@@ -229,6 +229,28 @@ public class FileControllerTest
 
         Mockito.verify(taskFactory, Mockito.times(1)).getObject();
         Mockito.verify(worker, Mockito.times(1)).addTasksToQueue(queueComicsWorkerTask);
+    }
+
+    @Test
+    public void testImportComicFilesEncoded()
+    {
+        String[] fileNamesEncoded = new String[]
+        {"e%3A%2Fcomics%20%26%20manga%2C%20etc%2B%2Ffirst_%231%3B.cbr",
+         "f%3A%2Fcomics%40Home%2F~%2Fla%24t%20-%20(2000's)!.cbz"};
+
+        QueueComicsWorkerTask dummyWorkerTask = new QueueComicsWorkerTask();
+
+        Mockito.when(taskFactory.getObject()).thenReturn(dummyWorkerTask);
+        Mockito.doNothing().when(worker).addTasksToQueue(Mockito.any(AddComicWorkerTask.class));
+
+        controller.importComicFiles(fileNamesEncoded, false);
+
+        Mockito.verify(taskFactory, Mockito.times(1)).getObject();
+        Mockito.verify(worker, Mockito.times(1)).addTasksToQueue(dummyWorkerTask);
+
+        assertEquals(2, dummyWorkerTask.filenames.size());
+        assertEquals("e:/comics & manga, etc+/first_#1;.cbr", dummyWorkerTask.filenames.get(0));
+        assertEquals("f:/comics@Home/~/la$t - (2000's)!.cbz", dummyWorkerTask.filenames.get(1));
     }
 
     @Test

--- a/web-frontend/src/app/comic/comic.service.ts
+++ b/web-frontend/src/app/comic/comic.service.ts
@@ -177,13 +177,9 @@ export class ComicService {
   }
 
   import_files_into_library(filenames: string[], delete_blocked_pages: boolean): Observable<any> {
-    filenames.forEach((filename, index, source) => source[index] = this.encode_filename(filename));
+    filenames.forEach((filename, index, source) => source[index] = encodeURIComponent(filename));
     const params = new HttpParams().set('filenames', filenames.toString()).set('delete_blocked_pages', delete_blocked_pages.toString());
     return this.http.post(`${this.api_url}/files/import`, params);
-  }
-
-  encode_filename(filename: string): string {
-    return filename.replace(/,/g, '%2C').replace(/#/g, '%23').replace(/&/g, '%26');
   }
 
   get_number_of_pending_imports(): Observable<any> {
@@ -207,9 +203,7 @@ export class ComicService {
   }
 
   get_cover_url_for_file(filename: string): string {
-    // not fond of this, but encodeURI was NOT doing it for me...
-    const encoded_filename = this.encode_filename(filename);
-    return `${this.api_url}/files/import/cover?filename=` + encoded_filename;
+    return `${this.api_url}/files/import/cover?filename=` + encodeURIComponent(filename);
   }
 
   get_issue_label_text_for_comic(comic: Comic): string {


### PR DESCRIPTION
…ort APIs

* added testImportComicFilesEncoded as a simple check that filename decode ok on import
* ignored some files the VS Code generates

## Status
**READY**

## Migrations
NO

## Description
Trying another JS function (encodeURIComponent) to safely send filenames, that may contain some problematic characters, to the server.
