### PR TITLE
[Issue #185] Consistent undefined comic id on the library view

### DIFF
--- a/web-frontend/src/app/comic/comic-list/comic-list.component.ts
+++ b/web-frontend/src/app/comic/comic-list/comic-list.component.ts
@@ -132,10 +132,10 @@ export class ComicListComponent implements OnInit {
   }
 
   get_image_url(comic: Comic): string {
-    if (comic.missing === true) {
-      return this.comic_service.get_url_for_missing_page();
-    } else {
+    if (comic.missing === false) {
       return this.comic_service.get_url_for_page_by_comic_index(comic.id, 0);
+    } else {
+      return this.comic_service.get_url_for_missing_page();
     }
   }
 


### PR DESCRIPTION
* change the logic here to consider missing=undefined as still missing which avoids an unnecessary request to the server when the value of current_comic is not yet properly initialized.

## Status
**READY**

## Migrations
NO

## Description
Avoiding an unnecessary call to the server while the values for the current comic have not yet been properly sourced.

There are probably a few ways to have done this (i.e. explicitly checking for undefined on the id values or initializing an empty Comic object with a value or two to indicate it's temporary nature) but this seemed like it was the lowest risk/impact and was isolated to where the error originated. It also didn't seem too far off base to suggest that in this particular location that a value of undefined for "missing" could also mean that the image was not yet ready to be retrieved.
