### PR TITLE
[Issue #230] Information alerts should disappear after a short time

### DIFF
--- a/web-frontend/src/app/app.component.html
+++ b/web-frontend/src/app/app.component.html
@@ -34,12 +34,13 @@
       </div>
     </div>
   </nav>
-  <div *ngIf='alert_count > 0' class='row justify-content-center'>
-    <div *ngFor='let key of object_keys(alert_messages)'
-      class='alert {{alert_messages[key].class}} w-75 text-center' role='alert'>
-      {{alert_messages[key].message}} <a id='alert-message-dismiss' href='#'
-      class='close' data-dismiss='alert' aria-label='close'
-      (click)='clear_alert_message(key)'>&times;</a>
+  <div *ngIf='alert_messages.length > 0'
+    class='row justify-content-center'>
+    <div *ngFor='let alert_message of alert_messages; let i = index'
+      class='alert {{alert_message[1]}} w-75 text-center' role='alert'>
+      {{alert_message[0]}} <a id='alert-message-dismiss' href='#'
+        class='close' data-dismiss='alert' aria-label='close'
+        (click)='clear_alert_message(i)'>&times;</a>
     </div>
   </div>
   <div class='row w-100'>

--- a/web-frontend/src/app/app.component.html
+++ b/web-frontend/src/app/app.component.html
@@ -34,13 +34,12 @@
       </div>
     </div>
   </nav>
-  <div *ngIf='alert_messages.length > 0'
-    class='row justify-content-center'>
-    <div *ngFor='let alert_message of alert_messages; let i = index'
-      class='alert {{alert_message[1]}} w-75 text-center' role='alert'>
-      {{alert_message[0]}} <a id='alert-message-dismiss' href='#'
-        class='close' data-dismiss='alert' aria-label='close'
-        (click)='clear_error_message(i)'>&times;</a>
+  <div *ngIf='alert_count > 0' class='row justify-content-center'>
+    <div *ngFor='let key of object_keys(alert_messages)'
+      class='alert {{alert_messages[key].class}} w-75 text-center' role='alert'>
+      {{alert_messages[key].message}} <a id='alert-message-dismiss' href='#'
+      class='close' data-dismiss='alert' aria-label='close'
+      (click)='clear_alert_message(key)'>&times;</a>
     </div>
   </div>
   <div class='row w-100'>

--- a/web-frontend/src/app/app.component.ts
+++ b/web-frontend/src/app/app.component.ts
@@ -52,7 +52,11 @@ export class AppComponent implements AfterViewInit {
     );
     this.alert_service.info_messages.subscribe(
       (message: string) => {
-        this.alert_messages.push([message, 'alert-info']);
+        const newLength = this.alert_messages.push([message, 'alert-info']);
+        const index = newLength - 1;
+        // create a timer to remove this info message after 5 seconds
+        const timer = setTimeout(() => { this.clear_error_message(index); }, 5000);
+        this.alert_messages[index].push(timer);
       }
     );
 
@@ -70,7 +74,14 @@ export class AppComponent implements AfterViewInit {
   }
 
   clear_error_message(index: number): void {
-    this.alert_messages.splice(index, 1);
+    if (this.alert_messages.length > index) {
+      if (this.alert_messages[index].length > 2) {
+        // cancel the timer if clear was clicked before it fired
+        const timeout = this.alert_messages[index][2];
+        clearTimeout(timeout);
+      }
+      this.alert_messages.splice(index, 1);
+    }
   }
 
   is_authenticated(): boolean {


### PR DESCRIPTION
* added a simple 5 second timeout to info alerts so they will clear themselves (matching on the text of the message)
* the timeout handle is added to the end of the individual message array so it can be cleared if "close" was clicked

## Status
**READY**

## Migrations
NO

## Description
When error or information messages are received from the AlertService, they are pushed on to the alert_messages array. Information messages also have a callback set to remove the message in 5 seconds by matching on the text of the message. In case someone clears the message before the time is up, the timeout handle is added to the end of the message array so the timeout can also be cleared whenever the message is.


